### PR TITLE
Clustering kwargs exposed

### DIFF
--- a/simple_diarizer/diarizer.py
+++ b/simple_diarizer/diarizer.py
@@ -187,6 +187,7 @@ class Diarizer:
         enhance_sim=True,
         extra_info=False,
         outfile=None,
+        **kwargs_clustering
     ):
         """
         Diarize a 16khz mono wav file, produces list of segments
@@ -260,6 +261,7 @@ class Diarizer:
             n_clusters=num_speakers,
             threshold=threshold,
             enhance_sim=enhance_sim,
+            **kwargs_clustering
         )
 
         print("Cleaning up output...")
@@ -278,7 +280,7 @@ class Diarizer:
             return {"clean_segments": cleaned_segments,
                     "embeds": embeds,
                     "segments": segments,
-                    "cluster_labels": cluster_labels} 
+                    "cluster_labels": cluster_labels}
 
     @staticmethod
     def rttm_output(segments, recname, outfile=None):
@@ -422,6 +424,7 @@ if __name__ == "__main__":
     wavfile = sys.argv[1]
     num_speakers = int(sys.argv[2])
     outfolder = sys.argv[3]
+    kwargs_clustering = dict(arg.split('=') for arg in sys.argv[4:]) # e.g. eigen_solver=lobpcg
 
     assert os.path.isfile(wavfile), "Couldn't find {}".format(wavfile)
 
@@ -444,4 +447,5 @@ if __name__ == "__main__":
         correct_wav,
         num_speakers=num_speakers,
         outfile=os.path.join(outfolder, "hyp.rttm"),
+        **kwargs_clustering
     )


### PR DESCRIPTION
I have exposed the kwargs for all of the sklearn-based clustering algorithms so that they can be called from cluster_SC(), cluster_AHC(), Diarizer.diarize() and the command line.

All kwargs available in the sklearn algorithms should be available. I noted that you have some default values for kwargs and have retained those.

I haven't done comprehensive testing. I won't be offended if you want to change the way it is implemented.

FYI, the reason I did this was that 'arpack' eigen solver in [sklearn.cluster.SpectralClustering](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.spectral_clustering.html) falls over when attempting to cluster a large number (>2k) of embeddings. Using the 'lobpcg' eigen solver appears to address this problem, but the eigen_solver kwarg could not be set from Diarizer.diarize() - now it can.